### PR TITLE
Handling if the ETS owner process dies

### DIFF
--- a/src/drivers/throttle_ets.erl
+++ b/src/drivers/throttle_ets.erl
@@ -28,7 +28,7 @@ reset(Scope, NextReset) ->
   ok.
 
 update(Scope, Key) ->
-  case ets:lookup(?STATE_TABLE, Scope) of
+  try ets:lookup(?STATE_TABLE, Scope) of
     [{Scope, TableId, Limit, NextReset}] ->
 
       %% add 1 to counter in position 2, if it's less or equal than Limit, default counter to 0
@@ -36,6 +36,9 @@ update(Scope, Key) ->
 
       {Count, Limit, NextReset};
     [] ->
+      rate_not_set
+  catch
+    error:badarg ->
       rate_not_set
   end.
 

--- a/test/throttle_test_SUITE.erl
+++ b/test/throttle_test_SUITE.erl
@@ -11,7 +11,8 @@
                     test_hour,
                     test_day,
                     test_custom_ms,
-                    rate_not_set]).
+                    rate_not_set,
+                    owner_process_died]).
 
 %% we want to repeat the same suit with the different drivers
 groups() ->
@@ -127,5 +128,14 @@ test_custom_ms(_Config) ->
 
 rate_not_set(_Config) ->
   rate_not_set = throttle:check(didnt_set, <<"john">>),
+
+  ok.
+
+owner_process_died(_Config) ->
+  spawn(fun() ->
+    %% This is a new process which creates the rate
+    throttle:setup(test_rate10, 3, per_second)
+  end),
+  rate_not_set = throttle:check(test_rate10, <<"john">>),
 
   ok.


### PR DESCRIPTION
I'm getting a lot of errors in tests, where the rates are created by processes that died before `throttle:check/2` is executed.

```
**throw:{error,badarg,
--
  | [{ets,lookup,[throttle_state_table, ***],[]},
  | {throttle_ets,update_counter,2,
...
```